### PR TITLE
feat: add group functions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,17 +12,17 @@ jobs:
     name: Update coverage badge
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.24.x'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: '1.24.x'
 
     - name: Test
       run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gofn
-![Coverage](https://img.shields.io/badge/Coverage-87.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-88.7%25-brightgreen)
 [![Go](https://github.com/devalexandre/gofn/actions/workflows/go.yml/badge.svg)](https://github.com/devalexandre/gofn/actions/workflows/go.yml)
 
 # library to use golang functional
@@ -31,6 +31,16 @@
         - [array.Shift](#arrayshift)
         - [array.Sort](#arraysort)
         - [array.GroupBy](#arraygroupby)
+        - [array.GroupSumBy](#arraygroupsumby)
+        - [array.GroupSumByWhere](#arraygroupsumbywhere)
+        - [array.GroupCountBy](#arraygroupcountby)
+        - [array.GroupReduceBy](#arraygroupreduceby)
+        - [array.GroupStatsBy](#arraygroupstatsby)
+        - [array.DistinctBy](#arraydistinctby)
+        - [array.IndexBy](#arrayindexby)
+        - [array.Partition](#arraypartition)
+        - [array.SortBy](#arraysortby)
+        - [array.Take, array.Skip, array.Chunk](#arraytake-arrayskip-arraychunk)
     - [chaining functions](#chaining-functions)
 
 
@@ -379,6 +389,160 @@ type Itens struct {
 	fmt.Println(len(grouped)) // 4
 	
 ```
+
+### array.GroupSumBy
+Group items by a key and sum a numeric value for each group.
+
+```go
+type Itens struct {
+	Name        string
+	Price       float64
+	Description string
+	Qty         int
+}
+
+itens := []Itens{
+	{"Item 1", 10.0, "Description 1", 1},
+	{"Item 2", 20.0, "Description 2", 2},
+	{"Item 3", 30.0, "Description 3", 3},
+	{"Item 4", 40.0, "Description 4", 10},
+	{"Item 4", 40.0, "Description 4", 15},
+	{"Item 4", 40.0, "Description 4", 25},
+}
+
+priceByName := array.GroupSumBy(itens,
+	func(item Itens) string { return item.Name },
+	func(item Itens) float64 { return item.Price },
+)
+
+qtyByName := array.GroupSumBy(itens,
+	func(item Itens) string { return item.Name },
+	func(item Itens) int { return item.Qty },
+)
+
+fmt.Println(priceByName["Item 4"]) // 120
+fmt.Println(qtyByName["Item 4"])   // 50
+```
+
+### array.GroupSumByWhere
+Filter, group and sum in one pass.
+
+```go
+priceByName := array.GroupSumByWhere(itens,
+	func(item Itens) bool { return item.Qty > 3 },
+	func(item Itens) string { return item.Name },
+	func(item Itens) float64 { return item.Price },
+)
+
+fmt.Println(priceByName["Item 4"]) // 120
+```
+
+### array.GroupCountBy
+Count rows by a key.
+
+```go
+countByName := array.GroupCountBy(itens, func(item Itens) string {
+	return item.Name
+})
+
+fmt.Println(countByName["Item 4"]) // 3
+```
+
+### array.GroupReduceBy
+Build custom summaries by group.
+
+```go
+type Summary struct {
+	TotalPrice float64
+	TotalQty   int
+}
+
+summaryByName := array.GroupReduceBy(itens,
+	func(item Itens) string {
+		return item.Name
+	},
+	func(acc Summary, item Itens) Summary {
+		acc.TotalPrice += item.Price
+		acc.TotalQty += item.Qty
+		return acc
+	},
+)
+
+fmt.Println(summaryByName["Item 4"]) // {120 50}
+```
+
+### array.GroupStatsBy
+Calculate count, sum, min, max and average by group.
+
+```go
+statsByName := array.GroupStatsBy(itens,
+	func(item Itens) string { return item.Name },
+	func(item Itens) float64 { return item.Price },
+)
+
+fmt.Println(statsByName["Item 4"].Count) // 3
+fmt.Println(statsByName["Item 4"].Sum)   // 120
+fmt.Println(statsByName["Item 4"].Avg)   // 40
+```
+
+### array.DistinctBy
+Keep the first row for each key.
+
+```go
+uniqueByName := array.DistinctBy(itens, func(item Itens) string {
+	return item.Name
+})
+
+fmt.Println(len(uniqueByName)) // 4
+```
+
+### array.IndexBy
+Create a map by key. If a key repeats, the last row wins.
+
+```go
+itemByName := array.IndexBy(itens, func(item Itens) string {
+	return item.Name
+})
+
+fmt.Println(itemByName["Item 4"].Qty) // 25
+```
+
+### array.Partition
+Split rows into matched and unmatched slices.
+
+```go
+highQty, lowQty := array.Partition(itens, func(item Itens) bool {
+	return item.Qty > 3
+})
+
+fmt.Println(len(highQty)) // 3
+fmt.Println(len(lowQty))  // 3
+```
+
+### array.SortBy
+Sort rows by a selected field without mutating the original slice.
+
+```go
+byQty := array.SortBy(itens, func(item Itens) int {
+	return item.Qty
+})
+
+fmt.Println(byQty[0].Qty) // 1
+```
+
+### array.Take, array.Skip, array.Chunk
+Use these helpers for pagination and batch processing.
+
+```go
+firstPage := array.Take(itens, 2)
+nextRows := array.Skip(itens, 2)
+batches := array.Chunk(itens, 2)
+
+fmt.Println(len(firstPage)) // 2
+fmt.Println(len(nextRows))  // 4
+fmt.Println(len(batches))   // 3
+```
+
 ## chaining functions
 
 You can chain the functions together.
@@ -397,4 +561,61 @@ data := array.Array[int]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
   
     fmt.Println(a) // [4 8 12 16 20]
 
+```
+
+You can also group and sum values after filtering.
+
+```go
+type Itens struct {
+	Name        string
+	Price       float64
+	Description string
+	Qty         int
+}
+
+data := array.Array[Itens]{
+	{"Item 1", 10.0, "Description 1", 1},
+	{"Item 2", 20.0, "Description 2", 2},
+	{"Item 3", 30.0, "Description 3", 3},
+	{"Item 4", 40.0, "Description 4", 10},
+	{"Item 4", 40.0, "Description 4", 15},
+	{"Item 4", 40.0, "Description 4", 25},
+}
+
+priceByName := data.
+	Filter(func(item Itens) bool {
+		return item.Qty > 3
+	}).
+	GroupSumBy(
+		func(item Itens) string { return item.Name },
+		func(item Itens) float64 { return item.Price },
+	)
+
+fmt.Println(priceByName["Item 4"]) // 120
+```
+
+Some helpers are also available in chain form.
+
+```go
+countByName := data.GroupCountBy(func(item Itens) string {
+	return item.Name
+})
+
+statsByName := data.GroupStatsBy(
+	func(item Itens) string { return item.Name },
+	func(item Itens) float64 { return item.Price },
+)
+
+uniqueByName := data.DistinctBy(func(item Itens) string {
+	return item.Name
+})
+
+highQty, lowQty := data.Partition(func(item Itens) bool {
+	return item.Qty > 3
+})
+
+page := data.
+	SortByFloat64(func(item Itens) float64 { return item.Price }).
+	Skip(10).
+	Take(10)
 ```

--- a/array/array.go
+++ b/array/array.go
@@ -61,3 +61,58 @@ func (a Array[T]) Sort(f func(i, j int) bool) Array[T] {
 func (a Array[T]) GroupBy(f func(T) string) map[string][]T {
 	return GroupBy(a, f)
 }
+
+func (a Array[T]) GroupSumBy(key func(T) string, value func(T) float64) map[string]float64 {
+	return GroupSumBy(a, key, value)
+}
+
+func (a Array[T]) GroupSumByWhere(where func(T) bool, key func(T) string, value func(T) float64) map[string]float64 {
+	return GroupSumByWhere(a, where, key, value)
+}
+
+func (a Array[T]) GroupCountBy(key func(T) string) map[string]int {
+	return GroupCountBy(a, key)
+}
+
+func (a Array[T]) GroupStatsBy(key func(T) string, value func(T) float64) map[string]GroupStats[float64] {
+	return GroupStatsBy(a, key, value)
+}
+
+func (a Array[T]) DistinctBy(key func(T) string) Array[T] {
+	return DistinctBy(a, key)
+}
+
+func (a Array[T]) IndexBy(key func(T) string) map[string]T {
+	return IndexBy(a, key)
+}
+
+func (a Array[T]) Partition(f func(T) bool) (Array[T], Array[T]) {
+	matched, unmatched := Partition(a, f)
+	return matched, unmatched
+}
+
+func (a Array[T]) SortByString(key func(T) string) Array[T] {
+	return SortBy(a, key)
+}
+
+func (a Array[T]) SortByFloat64(key func(T) float64) Array[T] {
+	return SortBy(a, key)
+}
+
+func (a Array[T]) Take(n int) Array[T] {
+	return Take(a, n)
+}
+
+func (a Array[T]) Skip(n int) Array[T] {
+	return Skip(a, n)
+}
+
+func (a Array[T]) Chunk(size int) []Array[T] {
+	chunks := Chunk(a, size)
+	result := make([]Array[T], len(chunks))
+	for i, chunk := range chunks {
+		result[i] = chunk
+	}
+
+	return result
+}

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -170,4 +170,113 @@ func TestArray(t *testing.T) {
 			t.Error("GroupBy failed. Got", grouped[key], "Expected items in original order")
 		}
 	})
+
+	t.Run("test GroupSumBy", func(t *testing.T) {
+
+		type Itens struct {
+			Name        string
+			Price       float64
+			Description string
+			Qty         int
+		}
+
+		itens := array.Array[Itens]{
+			{"Item 1", 10.0, "Description 1", 1},
+			{"Item 2", 20.0, "Description 2", 2},
+			{"Item 3", 30.0, "Description 3", 3},
+			{"Item 4", 40.0, "Description 4", 10},
+			{"Item 4", 40.0, "Description 4", 15},
+			{"Item 4", 40.0, "Description 4", 25},
+		}
+
+		priceByName := itens.
+			Filter(func(item Itens) bool {
+				return item.Qty > 3
+			}).
+			GroupSumBy(
+				func(item Itens) string { return item.Name },
+				func(item Itens) float64 { return item.Price },
+			)
+
+		if priceByName["Item 4"] != 120.0 {
+			t.Error("GroupSumBy failed. Got", priceByName["Item 4"], "Expected", 120.0)
+		}
+	})
+
+	t.Run("test row helper chain methods", func(t *testing.T) {
+
+		type Itens struct {
+			Name        string
+			Price       float64
+			Description string
+			Qty         int
+		}
+
+		itens := array.Array[Itens]{
+			{"Item 1", 10.0, "Description 1", 1},
+			{"Item 2", 20.0, "Description 2", 2},
+			{"Item 3", 30.0, "Description 3", 3},
+			{"Item 4", 40.0, "Description 4", 10},
+			{"Item 4", 40.0, "Description 4", 15},
+			{"Item 4", 40.0, "Description 4", 25},
+		}
+
+		sum := itens.GroupSumByWhere(
+			func(item Itens) bool { return item.Qty > 3 },
+			func(item Itens) string { return item.Name },
+			func(item Itens) float64 { return item.Price },
+		)
+		if sum["Item 4"] != 120 {
+			t.Error("GroupSumByWhere failed. Got", sum["Item 4"], "Expected", 120)
+		}
+
+		count := itens.GroupCountBy(func(item Itens) string { return item.Name })
+		if count["Item 4"] != 3 {
+			t.Error("GroupCountBy failed. Got", count["Item 4"], "Expected", 3)
+		}
+
+		stats := itens.GroupStatsBy(
+			func(item Itens) string { return item.Name },
+			func(item Itens) float64 { return item.Price },
+		)
+		if stats["Item 4"].Avg != 40 {
+			t.Error("GroupStatsBy failed. Got", stats["Item 4"], "Expected avg", 40)
+		}
+
+		distinct := itens.DistinctBy(func(item Itens) string { return item.Name })
+		if len(distinct) != 4 || distinct[3].Qty != 10 {
+			t.Error("DistinctBy failed. Got", distinct, "Expected first item for each name")
+		}
+
+		indexed := itens.IndexBy(func(item Itens) string { return item.Name })
+		if indexed["Item 4"].Qty != 25 {
+			t.Error("IndexBy failed. Got", indexed["Item 4"], "Expected last item for duplicated key")
+		}
+
+		highQty, lowQty := itens.Partition(func(item Itens) bool { return item.Qty > 3 })
+		if len(highQty) != 3 || len(lowQty) != 3 {
+			t.Error("Partition failed. Got", len(highQty), len(lowQty), "Expected", 3, 3)
+		}
+
+		byName := itens.SortByString(func(item Itens) string { return item.Name })
+		if byName[0].Name != "Item 1" || byName[len(byName)-1].Name != "Item 4" {
+			t.Error("SortByString failed. Got", byName)
+		}
+
+		byPrice := itens.SortByFloat64(func(item Itens) float64 { return item.Price })
+		if byPrice[0].Price != 10 || byPrice[len(byPrice)-1].Price != 40 {
+			t.Error("SortByFloat64 failed. Got", byPrice)
+		}
+
+		if got := itens.Take(2); len(got) != 2 || got[1].Name != "Item 2" {
+			t.Error("Take failed. Got", got, "Expected first two items")
+		}
+		if got := itens.Skip(3); len(got) != 3 || got[0].Qty != 10 {
+			t.Error("Skip failed. Got", got, "Expected last three items")
+		}
+		chunks := itens.Chunk(2)
+		if len(chunks) != 3 || len(chunks[2]) != 2 || chunks[2][1].Qty != 25 {
+			t.Error("Chunk failed. Got", chunks, "Expected three chunks with two items")
+		}
+	})
 }

--- a/array/functions.go
+++ b/array/functions.go
@@ -1,6 +1,7 @@
 package array
 
 import (
+	"cmp"
 	"fmt"
 	"math/rand/v2"
 	"slices"
@@ -12,6 +13,14 @@ type Number interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64 |
 		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr |
 		~float32 | ~float64
+}
+
+type GroupStats[V Number] struct {
+	Count int
+	Sum   V
+	Min   V
+	Max   V
+	Avg   float64
 }
 
 func Filter[T any](a []T, f func(T) bool) []T {
@@ -450,4 +459,169 @@ func GroupBy[T any, K comparable](w []T, key func(T) K) map[K][]T {
 	}
 
 	return m
+}
+
+/* GroupSumBy groups rows by key and sums a numeric value for each group.
+* Example:
+*   totalByName := GroupSumBy(items,
+*       func(item Item) string { return item.Name },
+*       func(item Item) float64 { return item.Price },
+*   )
+ */
+func GroupSumBy[T any, K comparable, V Number](w []T, key func(T) K, value func(T) V) map[K]V {
+	m := make(map[K]V)
+	for _, x := range w {
+		m[key(x)] += value(x)
+	}
+
+	return m
+}
+
+func GroupSumByWhere[T any, K comparable, V Number](w []T, where func(T) bool, key func(T) K, value func(T) V) map[K]V {
+	m := make(map[K]V)
+	for _, x := range w {
+		if !where(x) {
+			continue
+		}
+		m[key(x)] += value(x)
+	}
+
+	return m
+}
+
+func GroupCountBy[T any, K comparable](w []T, key func(T) K) map[K]int {
+	m := make(map[K]int)
+	for _, x := range w {
+		m[key(x)]++
+	}
+
+	return m
+}
+
+func GroupReduceBy[T any, K comparable, A any](w []T, key func(T) K, reduce func(A, T) A) map[K]A {
+	m := make(map[K]A)
+	for _, x := range w {
+		k := key(x)
+		m[k] = reduce(m[k], x)
+	}
+
+	return m
+}
+
+func GroupStatsBy[T any, K comparable, V Number](w []T, key func(T) K, value func(T) V) map[K]GroupStats[V] {
+	m := make(map[K]GroupStats[V])
+	for _, x := range w {
+		k := key(x)
+		v := value(x)
+		stats, ok := m[k]
+		if !ok {
+			m[k] = GroupStats[V]{
+				Count: 1,
+				Sum:   v,
+				Min:   v,
+				Max:   v,
+				Avg:   float64(v),
+			}
+			continue
+		}
+
+		stats.Count++
+		stats.Sum += v
+		if v < stats.Min {
+			stats.Min = v
+		}
+		if v > stats.Max {
+			stats.Max = v
+		}
+		stats.Avg = float64(stats.Sum) / float64(stats.Count)
+		m[k] = stats
+	}
+
+	return m
+}
+
+func DistinctBy[T any, K comparable](w []T, key func(T) K) []T {
+	result := make([]T, 0, len(w))
+	seen := make(map[K]struct{}, len(w))
+	for _, x := range w {
+		k := key(x)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		result = append(result, x)
+	}
+
+	return result
+}
+
+func IndexBy[T any, K comparable](w []T, key func(T) K) map[K]T {
+	m := make(map[K]T, len(w))
+	for _, x := range w {
+		m[key(x)] = x
+	}
+
+	return m
+}
+
+func Partition[T any](w []T, f func(T) bool) ([]T, []T) {
+	matched := make([]T, 0, len(w))
+	unmatched := make([]T, 0, len(w))
+	for _, x := range w {
+		if f(x) {
+			matched = append(matched, x)
+			continue
+		}
+		unmatched = append(unmatched, x)
+	}
+
+	return matched, unmatched
+}
+
+func SortBy[T any, K cmp.Ordered](w []T, key func(T) K) []T {
+	result := slices.Clone(w)
+	slices.SortStableFunc(result, func(a, b T) int {
+		return cmp.Compare(key(a), key(b))
+	})
+
+	return result
+}
+
+func Take[T any](w []T, n int) []T {
+	if n <= 0 {
+		return []T{}
+	}
+	if n > len(w) {
+		n = len(w)
+	}
+
+	return slices.Clone(w[:n])
+}
+
+func Skip[T any](w []T, n int) []T {
+	if n <= 0 {
+		return slices.Clone(w)
+	}
+	if n >= len(w) {
+		return []T{}
+	}
+
+	return slices.Clone(w[n:])
+}
+
+func Chunk[T any](w []T, size int) [][]T {
+	if size <= 0 {
+		panic("chunk size must be positive")
+	}
+
+	chunks := make([][]T, 0, (len(w)+size-1)/size)
+	for start := 0; start < len(w); start += size {
+		end := start + size
+		if end > len(w) {
+			end = len(w)
+		}
+		chunks = append(chunks, slices.Clone(w[start:end]))
+	}
+
+	return chunks
 }

--- a/array/functions_test.go
+++ b/array/functions_test.go
@@ -379,3 +379,151 @@ func TestGroupBy(t *testing.T) {
 		t.Error("GroupBy failed. Got", grouped[key], "Expected items in original order")
 	}
 }
+
+func TestGroupSumBy(t *testing.T) {
+	type Itens struct {
+		Name        string
+		Price       float64
+		Description string
+		Qty         int
+	}
+
+	itens := []Itens{
+		{"Item 1", 10.0, "Description 1", 1},
+		{"Item 2", 20.0, "Description 2", 2},
+		{"Item 3", 30.0, "Description 3", 3},
+		{"Item 4", 40.0, "Description 4", 10},
+		{"Item 4", 40.0, "Description 4", 15},
+		{"Item 4", 40.0, "Description 4", 25},
+	}
+
+	priceByName := array.GroupSumBy(itens,
+		func(item Itens) string { return item.Name },
+		func(item Itens) float64 { return item.Price },
+	)
+
+	if priceByName["Item 4"] != 120.0 {
+		t.Error("GroupSumBy failed. Got", priceByName["Item 4"], "Expected", 120.0)
+	}
+
+	qtyByName := array.GroupSumBy(itens,
+		func(item Itens) string { return item.Name },
+		func(item Itens) int { return item.Qty },
+	)
+
+	if qtyByName["Item 4"] != 50 {
+		t.Error("GroupSumBy failed. Got", qtyByName["Item 4"], "Expected", 50)
+	}
+}
+
+func TestRowHelpers(t *testing.T) {
+	type Summary struct {
+		TotalPrice float64
+		TotalQty   int
+	}
+	type Itens struct {
+		Name        string
+		Price       float64
+		Description string
+		Qty         int
+	}
+
+	itens := []Itens{
+		{"Item 1", 10.0, "Description 1", 1},
+		{"Item 2", 20.0, "Description 2", 2},
+		{"Item 3", 30.0, "Description 3", 3},
+		{"Item 4", 40.0, "Description 4", 10},
+		{"Item 4", 40.0, "Description 4", 15},
+		{"Item 4", 40.0, "Description 4", 25},
+	}
+
+	t.Run("GroupSumByWhere", func(t *testing.T) {
+		sum := array.GroupSumByWhere(itens,
+			func(item Itens) bool { return item.Qty > 3 },
+			func(item Itens) string { return item.Name },
+			func(item Itens) float64 { return item.Price },
+		)
+
+		if !reflect.DeepEqual(sum, map[string]float64{"Item 4": 120}) {
+			t.Error("GroupSumByWhere failed. Got", sum, "Expected", map[string]float64{"Item 4": 120})
+		}
+	})
+
+	t.Run("GroupCountBy", func(t *testing.T) {
+		count := array.GroupCountBy(itens, func(item Itens) string { return item.Name })
+		if count["Item 4"] != 3 {
+			t.Error("GroupCountBy failed. Got", count["Item 4"], "Expected", 3)
+		}
+	})
+
+	t.Run("GroupReduceBy", func(t *testing.T) {
+		summary := array.GroupReduceBy(itens,
+			func(item Itens) string { return item.Name },
+			func(acc Summary, item Itens) Summary {
+				acc.TotalPrice += item.Price
+				acc.TotalQty += item.Qty
+				return acc
+			},
+		)
+
+		if summary["Item 4"] != (Summary{TotalPrice: 120, TotalQty: 50}) {
+			t.Error("GroupReduceBy failed. Got", summary["Item 4"], "Expected", Summary{TotalPrice: 120, TotalQty: 50})
+		}
+	})
+
+	t.Run("GroupStatsBy", func(t *testing.T) {
+		stats := array.GroupStatsBy(itens,
+			func(item Itens) string { return item.Name },
+			func(item Itens) float64 { return item.Price },
+		)
+
+		expected := array.GroupStats[float64]{Count: 3, Sum: 120, Min: 40, Max: 40, Avg: 40}
+		if stats["Item 4"] != expected {
+			t.Error("GroupStatsBy failed. Got", stats["Item 4"], "Expected", expected)
+		}
+	})
+
+	t.Run("DistinctBy", func(t *testing.T) {
+		distinct := array.DistinctBy(itens, func(item Itens) string { return item.Name })
+		if len(distinct) != 4 || distinct[3].Qty != 10 {
+			t.Error("DistinctBy failed. Got", distinct, "Expected first item for each name")
+		}
+	})
+
+	t.Run("IndexBy", func(t *testing.T) {
+		indexed := array.IndexBy(itens, func(item Itens) string { return item.Name })
+		if indexed["Item 4"].Qty != 25 {
+			t.Error("IndexBy failed. Got", indexed["Item 4"], "Expected last item for duplicated key")
+		}
+	})
+
+	t.Run("Partition", func(t *testing.T) {
+		highQty, lowQty := array.Partition(itens, func(item Itens) bool { return item.Qty > 3 })
+		if len(highQty) != 3 || len(lowQty) != 3 {
+			t.Error("Partition failed. Got", len(highQty), len(lowQty), "Expected", 3, 3)
+		}
+	})
+
+	t.Run("SortBy", func(t *testing.T) {
+		sorted := array.SortBy(itens, func(item Itens) int { return item.Qty })
+		if sorted[0].Qty != 1 || sorted[len(sorted)-1].Qty != 25 {
+			t.Error("SortBy failed. Got", sorted, "Expected order by Qty")
+		}
+		if itens[0].Qty != 1 {
+			t.Error("SortBy mutated input. Got", itens, "Expected original input")
+		}
+	})
+
+	t.Run("TakeSkipChunk", func(t *testing.T) {
+		if got := array.Take(itens, 2); len(got) != 2 || got[1].Name != "Item 2" {
+			t.Error("Take failed. Got", got, "Expected first two items")
+		}
+		if got := array.Skip(itens, 3); len(got) != 3 || got[0].Qty != 10 {
+			t.Error("Skip failed. Got", got, "Expected last three items")
+		}
+		chunks := array.Chunk(itens, 2)
+		if len(chunks) != 3 || len(chunks[2]) != 2 || chunks[2][1].Qty != 25 {
+			t.Error("Chunk failed. Got", chunks, "Expected three chunks with two items")
+		}
+	})
+}

--- a/pipe/functions.go
+++ b/pipe/functions.go
@@ -1,6 +1,7 @@
 package pipe
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 
@@ -203,5 +204,93 @@ func GroupBy[T any, K comparable](f func(T) K) func([]T) ([]T, error) {
 			result = append(result, item)
 		}
 		return result, nil
+	}
+}
+
+func GroupSumBy[T any, K comparable, V Number](key func(T) K, value func(T) V) func([]T) (map[K]V, error) {
+	return func(a []T) (map[K]V, error) {
+		if len(a) == 0 {
+			return nil, fmt.Errorf("the input slice is empty")
+		}
+		return array.GroupSumBy(a, key, value), nil
+	}
+}
+
+func GroupSumByWhere[T any, K comparable, V Number](where func(T) bool, key func(T) K, value func(T) V) func([]T) (map[K]V, error) {
+	return func(a []T) (map[K]V, error) {
+		if len(a) == 0 {
+			return nil, fmt.Errorf("the input slice is empty")
+		}
+		return array.GroupSumByWhere(a, where, key, value), nil
+	}
+}
+
+func GroupCountBy[T any, K comparable](key func(T) K) func([]T) (map[K]int, error) {
+	return func(a []T) (map[K]int, error) {
+		if len(a) == 0 {
+			return nil, fmt.Errorf("the input slice is empty")
+		}
+		return array.GroupCountBy(a, key), nil
+	}
+}
+
+func GroupReduceBy[T any, K comparable, A any](key func(T) K, reduce func(A, T) A) func([]T) (map[K]A, error) {
+	return func(a []T) (map[K]A, error) {
+		if len(a) == 0 {
+			return nil, fmt.Errorf("the input slice is empty")
+		}
+		return array.GroupReduceBy(a, key, reduce), nil
+	}
+}
+
+func GroupStatsBy[T any, K comparable, V Number](key func(T) K, value func(T) V) func([]T) (map[K]array.GroupStats[V], error) {
+	return func(a []T) (map[K]array.GroupStats[V], error) {
+		if len(a) == 0 {
+			return nil, fmt.Errorf("the input slice is empty")
+		}
+		return array.GroupStatsBy(a, key, value), nil
+	}
+}
+
+func DistinctBy[T any, K comparable](key func(T) K) func([]T) ([]T, error) {
+	return func(a []T) ([]T, error) {
+		return array.DistinctBy(a, key), nil
+	}
+}
+
+func IndexBy[T any, K comparable](key func(T) K) func([]T) (map[K]T, error) {
+	return func(a []T) (map[K]T, error) {
+		return array.IndexBy(a, key), nil
+	}
+}
+
+func Partition[T any](f func(T) bool) func([]T) ([]T, []T, error) {
+	return func(a []T) ([]T, []T, error) {
+		matched, unmatched := array.Partition(a, f)
+		return matched, unmatched, nil
+	}
+}
+
+func SortBy[T any, K cmp.Ordered](key func(T) K) func([]T) ([]T, error) {
+	return func(a []T) ([]T, error) {
+		return array.SortBy(a, key), nil
+	}
+}
+
+func Take[T any](n int) func([]T) ([]T, error) {
+	return func(a []T) ([]T, error) {
+		return array.Take(a, n), nil
+	}
+}
+
+func Skip[T any](n int) func([]T) ([]T, error) {
+	return func(a []T) ([]T, error) {
+		return array.Skip(a, n), nil
+	}
+}
+
+func Chunk[T any](size int) func([]T) ([][]T, error) {
+	return func(a []T) ([][]T, error) {
+		return array.Chunk(a, size), nil
 	}
 }

--- a/pipe/functions_test.go
+++ b/pipe/functions_test.go
@@ -207,7 +207,7 @@ func TestShift(t *testing.T) {
 
 func TestSort(t *testing.T) {
 	lessFunc := func(i, j int) bool { return i < j }
-	f := Sort[int](lessFunc) 
+	f := Sort[int](lessFunc)
 	sortedSlice, err := f([]int{5, 3, 4, 1, 2})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -220,12 +220,12 @@ func TestSort(t *testing.T) {
 
 func TestUnshift(t *testing.T) {
 	elementsToAdd := []int{0, -1}
-	f := Unshift[int](elementsToAdd...) 
+	f := Unshift[int](elementsToAdd...)
 	resultSlice, err := f([]int{1, 2, 3, 4, 5})
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	expectedSlice := []int{0, -1, 1, 2, 3, 4, 5} 
+	expectedSlice := []int{0, -1, 1, 2, 3, 4, 5}
 	if !reflect.DeepEqual(resultSlice, expectedSlice) {
 		t.Errorf("Expected slice %v, got %v", expectedSlice, resultSlice)
 	}
@@ -262,4 +262,160 @@ func TestGroupByFunc(t *testing.T) {
 		t.Errorf("Expected %d groups, got %d", expectedGroupCount, len(groupedItems))
 	}
 
+}
+
+func TestGroupSumByFunc(t *testing.T) {
+	type Item struct {
+		Name        string
+		Price       float64
+		Description string
+		Qty         int
+	}
+
+	items := []Item{
+		{"Item 1", 10.0, "Description 1", 1},
+		{"Item 2", 20.0, "Description 2", 2},
+		{"Item 3", 30.0, "Description 3", 3},
+		{"Item 4", 40.0, "Description 4", 10},
+		{"Item 4", 40.0, "Description 4", 15},
+		{"Item 4", 40.0, "Description 4", 25},
+	}
+
+	groupSumByFunc := GroupSumBy(
+		func(item Item) string { return item.Name },
+		func(item Item) int { return item.Qty },
+	)
+
+	sumByName, err := groupSumByFunc(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if sumByName["Item 4"] != 50 {
+		t.Errorf("Expected %d, got %d", 50, sumByName["Item 4"])
+	}
+}
+
+func TestRowHelperFuncs(t *testing.T) {
+	type Summary struct {
+		TotalPrice float64
+		TotalQty   int
+	}
+	type Item struct {
+		Name        string
+		Price       float64
+		Description string
+		Qty         int
+	}
+
+	items := []Item{
+		{"Item 1", 10.0, "Description 1", 1},
+		{"Item 2", 20.0, "Description 2", 2},
+		{"Item 3", 30.0, "Description 3", 3},
+		{"Item 4", 40.0, "Description 4", 10},
+		{"Item 4", 40.0, "Description 4", 15},
+		{"Item 4", 40.0, "Description 4", 25},
+	}
+
+	sumWhere, err := GroupSumByWhere(
+		func(item Item) bool { return item.Qty > 3 },
+		func(item Item) string { return item.Name },
+		func(item Item) float64 { return item.Price },
+	)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if sumWhere["Item 4"] != 120 {
+		t.Errorf("Expected %v, got %v", 120.0, sumWhere["Item 4"])
+	}
+
+	count, err := GroupCountBy(func(item Item) string { return item.Name })(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if count["Item 4"] != 3 {
+		t.Errorf("Expected %d, got %d", 3, count["Item 4"])
+	}
+
+	summary, err := GroupReduceBy(
+		func(item Item) string { return item.Name },
+		func(acc Summary, item Item) Summary {
+			acc.TotalPrice += item.Price
+			acc.TotalQty += item.Qty
+			return acc
+		},
+	)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if summary["Item 4"] != (Summary{TotalPrice: 120, TotalQty: 50}) {
+		t.Errorf("Expected %v, got %v", Summary{TotalPrice: 120, TotalQty: 50}, summary["Item 4"])
+	}
+
+	stats, err := GroupStatsBy(
+		func(item Item) string { return item.Name },
+		func(item Item) float64 { return item.Price },
+	)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if stats["Item 4"].Count != 3 || stats["Item 4"].Avg != 40 {
+		t.Errorf("Expected Item 4 stats count 3 avg 40, got %v", stats["Item 4"])
+	}
+
+	distinct, err := DistinctBy(func(item Item) string { return item.Name })(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(distinct) != 4 || distinct[3].Qty != 10 {
+		t.Errorf("Expected first item for each name, got %v", distinct)
+	}
+
+	indexed, err := IndexBy(func(item Item) string { return item.Name })(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if indexed["Item 4"].Qty != 25 {
+		t.Errorf("Expected last item for duplicated key, got %v", indexed["Item 4"])
+	}
+
+	highQty, lowQty, err := Partition(func(item Item) bool { return item.Qty > 3 })(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(highQty) != 3 || len(lowQty) != 3 {
+		t.Errorf("Expected partition sizes 3 and 3, got %d and %d", len(highQty), len(lowQty))
+	}
+
+	sorted, err := SortBy(func(item Item) int { return item.Qty })(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if sorted[0].Qty != 1 || sorted[len(sorted)-1].Qty != 25 {
+		t.Errorf("Expected order by Qty, got %v", sorted)
+	}
+
+	taken, err := Take[Item](2)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(taken) != 2 || taken[1].Name != "Item 2" {
+		t.Errorf("Expected first two items, got %v", taken)
+	}
+
+	skipped, err := Skip[Item](3)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(skipped) != 3 || skipped[0].Qty != 10 {
+		t.Errorf("Expected last three items, got %v", skipped)
+	}
+
+	chunks, err := Chunk[Item](2)(items)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(chunks) != 3 || len(chunks[2]) != 2 || chunks[2][1].Qty != 25 {
+		t.Errorf("Expected three chunks with two items, got %v", chunks)
+	}
 }


### PR DESCRIPTION
# Release Notes

## Go 1.24 Functional Helpers Update

This release updates `gofn` for Go 1.24 and expands the library with helpers focused on working with large slices of records in a cleaner, functional style.

### Highlights

- Updated the module target to Go 1.24.
- Modernized internal implementations with Go standard library helpers such as `slices`, `cmp`, and `math/rand/v2`.
- Added row-oriented aggregation helpers to reduce repetitive `for` and `if` blocks.
- Improved grouping behavior so `GroupBy` now stores the grouped rows instead of returning empty groups.
- Added more tests around grouping, aggregation, sorting, partitioning, pagination, and batching.

### New Array Helpers

The `array` package now includes:

- `GroupSumBy`: group rows by a key and sum a numeric value.
- `GroupSumByWhere`: filter, group, and sum in a single pass.
- `GroupCountBy`: count rows by key.
- `GroupReduceBy`: build custom aggregate summaries by key.
- `GroupStatsBy`: calculate count, sum, min, max, and average by key.
- `DistinctBy`: keep the first row for each key.
- `IndexBy`: create a map by key, keeping the last row for duplicate keys.
- `Partition`: split a slice into matching and non-matching rows.
- `SortBy`: sort by a selected ordered field without mutating the original slice.
- `Take`: return the first `n` rows.
- `Skip`: skip the first `n` rows.
- `Chunk`: split rows into batches.

### Chaining Support

The `array.Array[T]` chain API now includes practical methods for common record workflows:

- `GroupSumBy`
- `GroupSumByWhere`
- `GroupCountBy`
- `GroupStatsBy`
- `DistinctBy`
- `IndexBy`
- `Partition`
- `SortByString`
- `SortByFloat64`
- `Take`
- `Skip`
- `Chunk`

Because Go does not currently support method-specific type parameters, some chained helpers use practical fixed key/value types. For fully generic keys and numeric value types, use the package-level functions.

### Pipe Support

The `pipe` package now includes adapters for the new helpers:

- `GroupSumBy`
- `GroupSumByWhere`
- `GroupCountBy`
- `GroupReduceBy`
- `GroupStatsBy`
- `DistinctBy`
- `IndexBy`
- `Partition`
- `SortBy`
- `Take`
- `Skip`
- `Chunk`

### Example

```go
type Item struct {
	Name  string
	Price float64
	Qty   int
}

items := []Item{
	{"Item 1", 10.0, 1},
	{"Item 4", 40.0, 10},
	{"Item 4", 40.0, 15},
	{"Item 4", 40.0, 25},
}

totalByName := array.GroupSumBy(items,
	func(item Item) string { return item.Name },
	func(item Item) float64 { return item.Price },
)

fmt.Println(totalByName["Item 4"]) // 120
```

For custom summaries:

```go
type Summary struct {
	TotalPrice float64
	TotalQty   int
}

summaryByName := array.GroupReduceBy(items,
	func(item Item) string {
		return item.Name
	},
	func(acc Summary, item Item) Summary {
		acc.TotalPrice += item.Price
		acc.TotalQty += item.Qty
		return acc
	},
)

fmt.Println(summaryByName["Item 4"]) // {120 50}
```

### Compatibility

The existing public APIs remain available. The changes are intended to preserve the current usage style while adding new helpers and improving correctness.

One behavioral fix to note: `GroupBy` now returns populated groups. Previous behavior created the group keys but did not append the matching rows.

### Verification

The release was validated with:

```sh
go test -count=1 ./...
go vet ./...
```

Local coverage after these changes is `88.7%`.
